### PR TITLE
Use EIP based DNS name as a `public_dns` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ resource "aws_ami_from_instance" "example" {
 | `id`                | Disambiguated ID                                                   |
 | `private_dns`       | Normalized name                                                    |
 | `private_ip`        | Normalized namespace                                               |
-| `public_hostname`   | Normalized name                                                    |
 | `public_ip`         | Public IP of instance (or EIP )                                    |
 | `public_dns`        | Public DNS of instance (or DNS of EIP)                             |
 | `ssh_key_pair`      | Name of used AWS SSH key                                           |

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ resource "aws_ami_from_instance" "example" {
 | Name                | Description                                                        |
 |:--------------------|:-------------------------------------------------------------------|
 | `id`                | Disambiguated ID                                                   |
-| `public_dns`        | Normalized name                                                    |
-| `public_ip`         | Normalized namespace                                               |
 | `private_dns`       | Normalized name                                                    |
 | `private_ip`        | Normalized namespace                                               |
+| `public_hostname`   | Normalized name                                                    |
+| `public_ip`         | Public IP of instance (or EIP )                                    |
+| `public_dns`        | Public DNS of instance (or DNS of EIP)                             |
 | `ssh_key_pair`      | Name of used AWS SSH key                                           |
 | `security_group_id` | ID on the new AWS Security Group associated with creating instance |
 | `role`              | Name of AWS IAM Role associated with creating instance             |

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ resource "aws_eip" "default" {
 module "ansible" {
   source    = "git::https://github.com/cloudposse/tf_ansible.git?ref=tags/0.3.4"
   arguments = "${var.ansible_arguments}"
-  envs      = "${compact(concat(var.ansible_envs, list("host=${var.associate_public_ip_address ? aws_instance.default.public_dns : aws_instance.default.private_dns }")))}"
+  envs      = "${compact(concat(var.ansible_envs, list("host=${var.associate_public_ip_address ? join("", null_resource.eip.*.triggers.public_dns) : aws_instance.default.private_dns }")))}"
   playbook  = "${var.ansible_playbook}"
   dry_run   = "${var.ansible_dry_run}"
 }

--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,7 @@ resource "aws_instance" "default" {
 }
 
 resource "aws_eip" "default" {
-  count    = "${signum(length(var.associate_public_ip_address)) == 1 ? 1 : 0}"
+  count    = "${var.associate_public_ip_address ? 1 : 0}"
   instance = "${aws_instance.default.id}"
   vpc      = true
 }
@@ -155,7 +155,7 @@ resource "aws_cloudwatch_metric_alarm" "default" {
 }
 
 resource "null_resource" "eip" {
-  count = "${signum(length(var.associate_public_ip_address)) == 1 ? 1 : 0}"
+  count = "${var.associate_public_ip_address ? 1 : 0}"
 
   triggers {
     public_dns = "ec2-${replace(aws_eip.default.public_ip, ".", "-")}.${data.aws_region.default.name == "us-east-1" ? "compute-1" : "${data.aws_region.default.name}.compute"}.amazonaws.com"

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ resource "aws_eip" "default" {
 module "ansible" {
   source    = "git::https://github.com/cloudposse/tf_ansible.git?ref=tags/0.3.4"
   arguments = "${var.ansible_arguments}"
-  envs      = "${compact(concat(var.ansible_envs, list("host=${var.associate_public_ip_address ? aws_eip.default.public_ip : aws_instance.default.private_dns }")))}"
+  envs      = "${compact(concat(var.ansible_envs, list("host=${var.associate_public_ip_address ? aws_eip.default.public_ip : aws_instance.default.private_ip }")))}"
   playbook  = "${var.ansible_playbook}"
   dry_run   = "${var.ansible_dry_run}"
 }

--- a/main.tf
+++ b/main.tf
@@ -153,3 +153,11 @@ resource "aws_cloudwatch_metric_alarm" "default" {
     "${null_resource.check_alarm_action.triggers.action}",
   ]
 }
+
+resource "null_resource" "eip" {
+  count = "${signum(length(var.associate_public_ip_address)) == 1 ? 1 : 0}"
+
+  triggers {
+    dns = "ec2-${replace(aws_eip.default.public_ip, ".", "-")}-${data.aws_region.default.name}.compute.amazonaws.com"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -113,15 +113,14 @@ resource "aws_eip" "default" {
 
 # Apply the provisioner module for this resource
 module "ansible" {
-  source    = "git::https://github.com/cloudposse/tf_ansible.git?ref=tags/0.3.4"
+  source    = "git::https://github.com/cloudposse/tf_ansible.git?ref=tags/0.3.6"
   arguments = "${var.ansible_arguments}"
-  envs      = "${compact(concat(var.ansible_envs, list("host=${var.associate_public_ip_address ? aws_eip.default.public_ip : aws_instance.default.private_ip }")))}"
+  envs      = "${compact(concat(var.ansible_envs, list("host=${var.associate_public_ip_address ? join("", aws_eip.default.*.public_ip) : aws_instance.default.private_ip }")))}"
   playbook  = "${var.ansible_playbook}"
   dry_run   = "${var.ansible_dry_run}"
 }
 
 # Restart dead or hung instance
-
 data "aws_region" "default" {
   current = true
 }

--- a/main.tf
+++ b/main.tf
@@ -158,6 +158,6 @@ resource "null_resource" "eip" {
   count = "${signum(length(var.associate_public_ip_address)) == 1 ? 1 : 0}"
 
   triggers {
-    dns = "ec2-${replace(aws_eip.default.public_ip, ".", "-")}-${data.aws_region.default.name}.compute.amazonaws.com"
+    public_dns = "ec2-${replace(aws_eip.default.public_ip, ".", "-")}.${data.aws_region.default.name == "us-east-1" ? "compute-1" : "${data.aws_region.default.name}.compute"}.amazonaws.com"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ resource "aws_eip" "default" {
 module "ansible" {
   source    = "git::https://github.com/cloudposse/tf_ansible.git?ref=tags/0.3.4"
   arguments = "${var.ansible_arguments}"
-  envs      = "${compact(concat(var.ansible_envs, list("host=${var.associate_public_ip_address ? join("", null_resource.eip.*.triggers.public_dns) : aws_instance.default.private_dns }")))}"
+  envs      = "${compact(concat(var.ansible_envs, list("host=${var.associate_public_ip_address ? aws_eip.default.public_ip : aws_instance.default.private_dns }")))}"
   playbook  = "${var.ansible_playbook}"
   dry_run   = "${var.ansible_dry_run}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "public_ip" {
-  value = "${coalesce(aws_eip.default.public_ip, aws_instance.default.public_ip)}"
+  value = "${coalesce(join("", aws_eip.default.*.public_ip), aws_instance.default.public_ip)}"
 }
 
 output "private_ip" {
@@ -11,7 +11,7 @@ output "private_dns" {
 }
 
 output "public_dns" {
-  value = "${coalesce(null_resource.eip.triggers.public_dns, aws_instance.default.public_dns)}"
+  value = "${coalesce(join("", null_resource.eip.*.triggers.public_dns), aws_instance.default.public_dns)}"
 }
 
 output "id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,7 +11,7 @@ output "private_dns" {
 }
 
 output "public_dns" {
-  value = "${aws_instance.default.public_dns}"
+  value = "${coalesce(null_resource.eip.triggers.dns, aws_instance.default.public_dns)}"
 }
 
 output "id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "public_ip" {
-  value = "${aws_eip.default.public_ip}"
+  value = "${coalesce(aws_eip.default.public_ip, aws_instance.default.public_ip)}"
 }
 
 output "private_ip" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,7 +11,7 @@ output "private_dns" {
 }
 
 output "public_dns" {
-  value = "${coalesce(null_resource.eip.triggers.dns, aws_instance.default.public_dns)}"
+  value = "${coalesce(null_resource.eip.triggers.public_dns, aws_instance.default.public_dns)}"
 }
 
 output "id" {


### PR DESCRIPTION
## what
* Use `aws_eip.default.public_ip` as DNS name endpoint

## why
* by request in task https://app.asana.com/0/415062006611341/423680287658574


terraform plan:
<img width="352" alt="screenshot 2017-09-08 18 54 34" src="https://user-images.githubusercontent.com/26582191/30220223-4c2a486a-94c7-11e7-9e8f-815f77e1be2e.png">